### PR TITLE
deleting empty spaces which cause an error

### DIFF
--- a/ASPLOS23/functionality_check/GPT2-335M-A100-CB-Breakdown.sh
+++ b/ASPLOS23/functionality_check/GPT2-335M-A100-CB-Breakdown.sh
@@ -47,7 +47,7 @@ TOTAL_ARGS="--num-layers 24 \
             --pipeline-model-parallel-size $PIPELINE_MP_SIZE \
             --experiment_name GPT2-335M-CB-Breakdown \
             --DDP-impl local \
-            --inter_grad_comp \   
+            --inter_grad_comp \
             --inter_grad_comp_rank 16 \
             --inter_grad_comp_epilogue_only \
             --use_error_feedback \


### PR DESCRIPTION
I found that there are extra empty spaces in a script and it caused an error.
You would know '\\' character is regarded as different from '\   ' in a script.